### PR TITLE
Fixed error caused by language is empty

### DIFF
--- a/renderer/src/utils/UserUtils.ts
+++ b/renderer/src/utils/UserUtils.ts
@@ -15,8 +15,10 @@ export default class LinkUtils {
   }
 
   static getUserLanguageTotal(languages: any) {
+    if (!languages) return 0;
     const values = Object.keys(languages).map((language) => languages[language]);
 
+    if (!values.length) return 0;
     return values.reduce((sum, value) => sum + value);
   }
 


### PR DESCRIPTION
[픽스 사항]
languages가 비어있음에 따라 이어지는 로직에 reference error가 발생하는 문제 해결